### PR TITLE
feat(EPAMCD-294): upgrade eslint-plugin-jest dependency

### DIFF
--- a/packages/eslint-config-episource-base/package.json
+++ b/packages/eslint-config-episource-base/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "eslint": "^7.10.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^24.1.0",
+    "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-prettier": "^3.1.4",
     "prettier": "^2.1.2",
     "typescript": "^4.0.3"

--- a/packages/eslint-config-episource/package.json
+++ b/packages/eslint-config-episource/package.json
@@ -42,7 +42,7 @@
     "babel-eslint": "^10.1.0",
     "eslint": "^7.10.0",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^24.1.0",
+    "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4108,6 +4108,13 @@ eslint-plugin-jest@^24.1.0:
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
+eslint-plugin-jest@^24.3.6:
+  version "24.3.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.3.6.tgz#5f0ca019183c3188c5ad3af8e80b41de6c8e9173"
+  integrity sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^4.0.1"
+
 eslint-plugin-jsx-a11y@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz#99ef7e97f567cc6a5b8dd5ab95a94a67058a2660"


### PR DESCRIPTION
BREAKING CHANGE: This implicitly updates the jest dependency to ^26.0.0.