### PR TITLE
feat: enable arrow-body-style rule

### DIFF
--- a/packages/eslint-config-episource-base/rules/es6.js
+++ b/packages/eslint-config-episource-base/rules/es6.js
@@ -14,9 +14,7 @@ module.exports = {
   rules: {
     // enforces no braces where they can be omitted
     // https://eslint.org/docs/rules/arrow-body-style
-    // Disabled due to conflict with prettier
-    // https://github.com/prettier/eslint-config-prettier#arrow-body-style-and-prefer-arrow-callback
-    'arrow-body-style': ['off'],
+    'arrow-body-style': ['error', 'as-needed'],
 
     // require parens in arrow function arguments
     // https://eslint.org/docs/rules/arrow-parens


### PR DESCRIPTION
This can cause conflicts with prettier, but there is a manual
workaround by adding a closing paren to affected functions.