### PR TITLE
feat: disable import/prefer-default-export

### DIFF
--- a/packages/eslint-config-episource-base/rules/imports.js
+++ b/packages/eslint-config-episource-base/rules/imports.js
@@ -144,7 +144,7 @@ module.exports = {
 
     // Require modules with a single export to use a default export
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
-    'import/prefer-default-export': 'error',
+    'import/prefer-default-export': 'off',
 
     // Restrict which files can be imported in a given folder
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-restricted-paths.md


### PR DESCRIPTION
We disable this rule almost everywhere. Additionally, frameworks
like nest expect a single file to have a single named export.