### PR TITLE
fix: when using ts, use correct no-shadow

### DIFF
--- a/packages/eslint-config-episource-base/typescript.js
+++ b/packages/eslint-config-episource-base/typescript.js
@@ -18,5 +18,7 @@ module.exports = {
   },
   rules: {
     'prettier/prettier': 'error',
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': 'error',
   },
 };


### PR DESCRIPTION
Per https://github.com/typescript-eslint/typescript-eslint/issues/2483