### PR TITLE
feat: add pr rules

### DIFF
--- a/packages/commitlint-config/README.md
+++ b/packages/commitlint-config/README.md
@@ -15,3 +15,11 @@ Run the following from your project root:
 ```sh
 echo "module.exports = {extends: ['@episource/commitlint-config']}" > commitlint.config.js
 ```
+
+## Custom Rules
+
+- `@episource/dependencies` - Use to enforce the presence of a dependencies
+  array in a commit subject, e.g. `feat: thing [api]`. An empty array should be
+  used if there are no dependencies.
+- `@episource/story-link` - Use to enforce the presence of a story link in the
+  commit scope, e.g. `feat(sc-123): thing`.

--- a/packages/commitlint-config/commitlint.config.js
+++ b/packages/commitlint-config/commitlint.config.js
@@ -1,6 +1,40 @@
+const STORY_REGEX = /^sc-\d+/;
+const DEPS_REGEX = /\[[^\]]*\]$/;
+
+const withWhen =
+  (when = 'always') =>
+  test => {
+    if (when === 'always') {
+      return !!test;
+    }
+    return !test;
+  };
+
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'scope-case': [2, 'always', ['kebab-case']],
   },
+  plugins: [
+    {
+      rules: {
+        '@episource/dependencies': function dependencies(parsed, when) {
+          const test = withWhen(when);
+          const { subject } = parsed;
+          return [
+            test(subject && !!subject.match(DEPS_REGEX)),
+            'Your subject must contain a dependencies array, e.g. "feat: did the thing [dependency1]".\n\tUse an empty array if there are no dependencies.',
+          ];
+        },
+        '@episource/story-link': function storyLink(parsed, when) {
+          const test = withWhen(when);
+          const { scope } = parsed;
+          return [
+            test(scope && !!scope.match(STORY_REGEX)),
+            'Your scope must contain a shortcut story link, e.g. "feat(sc-123): did the thing"',
+          ];
+        },
+      },
+    },
+  ],
 };

--- a/packages/commitlint-config/commitlint.config.js
+++ b/packages/commitlint-config/commitlint.config.js
@@ -30,7 +30,7 @@ module.exports = {
           const testCondition = withWhen(when);
           const { scope } = parsed;
           return [
-            testCondition(scope && !!`${scope}`.match(STORY_REGEX)),
+            testCondition(!scope || !!`${scope}`.match(STORY_REGEX)),
             'Your scope must contain a shortcut story link, e.g. "feat(sc-123): did the thing"',
           ];
         },

--- a/packages/commitlint-config/commitlint.config.js
+++ b/packages/commitlint-config/commitlint.config.js
@@ -19,18 +19,18 @@ module.exports = {
     {
       rules: {
         '@episource/dependencies': function dependencies(parsed, when) {
-          const test = withWhen(when);
+          const testCondition = withWhen(when);
           const { subject } = parsed;
           return [
-            test(subject && !!subject.match(DEPS_REGEX)),
+            testCondition(subject && !!`${subject}`.match(DEPS_REGEX)),
             'Your subject must contain a dependencies array, e.g. "feat: did the thing [dependency1]".\n\tUse an empty array if there are no dependencies.',
           ];
         },
         '@episource/story-link': function storyLink(parsed, when) {
-          const test = withWhen(when);
+          const testCondition = withWhen(when);
           const { scope } = parsed;
           return [
-            test(scope && !!scope.match(STORY_REGEX)),
+            testCondition(scope && !!`${scope}`.match(STORY_REGEX)),
             'Your scope must contain a shortcut story link, e.g. "feat(sc-123): did the thing"',
           ];
         },

--- a/packages/commitlint-config/commitlint.config.js
+++ b/packages/commitlint-config/commitlint.config.js
@@ -1,4 +1,4 @@
-const STORY_REGEX = /^sc-\d+/;
+const STORY_REGEX = /^sc-\d+$/;
 const DEPS_REGEX = /\[[^\]]*\]$/;
 
 const withWhen =


### PR DESCRIPTION
These rules can be used to test commits to align with desired PR formatting.

@episource/dependencies - tests to ensure commit messages include a dependencies array, e.g. 'feat: thing [medicare-api]'

@episource/story-link - tests to ensure commit messages include a
link to the story in the scope field, e.g. 'feat(sc-123): thing'